### PR TITLE
FIX: category ingredient combined search, styling

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -60,9 +60,11 @@ i {
   position: fixed;
   left: 5%;
   top:  20px; 
-
-}; 
-
+}
+#how-it-works h4 {
+  color: white; 
+  font-family: 'Convergence';
+}
 /* header  */
 h1 {
     display: flex;

--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -198,6 +198,7 @@ submitBtn.on('click', async (event) => {
                         ingArray.push(ingResponse['drinks'][i]['idDrink']); 
                     }
                 }
+                console.log(ingArray)
             
             let catResponse = await $.ajax({
                 method: 'GET',
@@ -208,10 +209,11 @@ submitBtn.on('click', async (event) => {
                         catArray.push(catResponse['drinks'][i]['idDrink']); 
                     }
                 }
+                console.log(catArray)
 
             ingArray.forEach(ingID => {
                 if (catArray.find(catID => catID === ingID)) {
-                    IDnums.push(item);
+                    IDnums.push(ingID);
                 }
             }) 
             if (IDnums.length > numberOfResponses) {


### PR DESCRIPTION
Category ingredient combined search - one variable `item` had not been update from a previous change to be either `catID` or `ingID` (in this case they should have the same value, so either can be used.

Styling - more stying to how it works modal to override universal h4 styling